### PR TITLE
Fix typo in colony detection comment

### DIFF
--- a/colony_analysis/core/detection.py
+++ b/colony_analysis/core/detection.py
@@ -342,7 +342,7 @@ class ColonyDetector:
 
         return colonies
 
-    #Hybird detection methods
+    # Hybrid detection methods
     def _detect_auto_mode_refined(self, img: np.ndarray) -> List[Dict]:
         """改进的auto检测：专门针对孔板优化"""
         logging.info("使用孔板优化的auto检测...")


### PR DESCRIPTION
## Summary
- fix typo in detection comment for hybrid methods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417fe638888332a6b6fa3196b60ab7